### PR TITLE
Add support for defining log levels

### DIFF
--- a/src/error-types/BaseError.ts
+++ b/src/error-types/BaseError.ts
@@ -14,12 +14,23 @@ export class BaseError extends ExtendableError implements IBaseError {
   protected _causedBy: any
   protected _safeMetadata: Record<string, any>
   protected _metadata: Record<string, any>
+  protected _logLevel: string | number
 
   constructor (message: string) {
     super(message)
 
     this._safeMetadata = {}
     this._metadata = {}
+  }
+
+  /**
+   * Assign a log level to the error. Useful if you want to
+   * determine which log level to use when logging the error.
+   * @param {string|number} logLevel
+   */
+  withLogLevel (logLevel: string | number) {
+    this._logLevel = logLevel
+    return this
   }
 
   /**
@@ -56,6 +67,13 @@ export class BaseError extends ExtendableError implements IBaseError {
   withErrorSubCode (subCode: string | number) {
     this._subCode = subCode
     return this
+  }
+
+  /**
+   * Gets the log level assigned to the error
+   */
+  getLogLevel () {
+    return this._logLevel
   }
 
   /**

--- a/src/error-types/BaseRegistryError.ts
+++ b/src/error-types/BaseRegistryError.ts
@@ -17,6 +17,10 @@ export class BaseRegistryError extends BaseError {
       this.withStatusCode(highLevelErrorDef.statusCode)
     }
 
+    if (highLevelErrorDef.logLevel) {
+      this.withLogLevel(highLevelErrorDef.logLevel)
+    }
+
     if (lowLevelErrorDef.statusCode) {
       this.withStatusCode(lowLevelErrorDef.statusCode)
     }
@@ -27,6 +31,10 @@ export class BaseRegistryError extends BaseError {
 
     if (lowLevelErrorDef.subCode) {
       this.withErrorSubCode(lowLevelErrorDef.subCode)
+    }
+
+    if (lowLevelErrorDef.logLevel) {
+      this.withLogLevel(lowLevelErrorDef.logLevel)
     }
   }
 }

--- a/src/error-types/__tests__/BaseRegistryError.test.ts
+++ b/src/error-types/__tests__/BaseRegistryError.test.ts
@@ -37,43 +37,90 @@ describe('BaseRegistryError', () => {
     expect(err.stack).toBeDefined()
   })
 
-  it('should use the default high level error code', () => {
-    const err = new BaseRegistryError(
-      {
-        code: 'TEST_ERR',
-        statusCode: 300
-      },
-      {
-        message: 'This is a test error'
-      }
-    )
+  describe('error codes', () => {
+    it('should use the default high level error code', () => {
+      const err = new BaseRegistryError(
+        {
+          code: 'TEST_ERR',
+          statusCode: 300
+        },
+        {
+          message: 'This is a test error'
+        }
+      )
 
-    expect(err.toJSON()).toEqual(
-      expect.objectContaining({
-        statusCode: 300
-      })
-    )
+      expect(err.toJSON()).toEqual(
+        expect.objectContaining({
+          statusCode: 300
+        })
+      )
 
-    expect(err.stack).toBeDefined()
+      expect(err.stack).toBeDefined()
+    })
+
+    it('should use the low level error code', () => {
+      const err = new BaseRegistryError(
+        {
+          code: 'TEST_ERR'
+        },
+        {
+          message: 'This is a test error',
+          statusCode: 500
+        }
+      )
+
+      expect(err.toJSON()).toEqual(
+        expect.objectContaining({
+          statusCode: 500
+        })
+      )
+
+      expect(err.stack).toBeDefined()
+    })
   })
 
-  it('should use the low level error code', () => {
-    const err = new BaseRegistryError(
-      {
-        code: 'TEST_ERR'
-      },
-      {
-        message: 'This is a test error',
-        statusCode: 500
-      }
-    )
+  describe('log levels', () => {
+    it('should use the default high level log level', () => {
+      const err = new BaseRegistryError(
+        {
+          code: 'TEST_ERR',
+          logLevel: 'debug'
+        },
+        {
+          message: 'This is a test error'
+        }
+      )
 
-    expect(err.toJSON()).toEqual(
-      expect.objectContaining({
-        statusCode: 500
-      })
-    )
+      expect(err.getLogLevel()).toBe('debug')
+    })
 
-    expect(err.stack).toBeDefined()
+    it('should use the low level log level', () => {
+      const err = new BaseRegistryError(
+        {
+          code: 'TEST_ERR',
+          logLevel: 'debug'
+        },
+        {
+          message: 'This is a test error',
+          logLevel: 'trace'
+        }
+      )
+
+      expect(err.getLogLevel()).toBe('trace')
+    })
+
+    it('should use the low level log level 2', () => {
+      const err = new BaseRegistryError(
+        {
+          code: 'TEST_ERR'
+        },
+        {
+          message: 'This is a test error',
+          logLevel: 'trace'
+        }
+      )
+
+      expect(err.getLogLevel()).toBe('trace')
+    })
   })
 })

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -13,6 +13,14 @@ export interface HighLevelError {
    * default if a Low Level Error status code is not specified or defined.
    */
   statusCode?: string | number
+
+  /**
+   * A log level to associate with this error type since not all errors
+   * may be considered an 'error' log level type when combined with
+   * a logger. Used as the default if a Low Level Error log level
+   * is not defined.
+   */
+  logLevel?: string | number
 }
 
 /**
@@ -46,6 +54,13 @@ export interface LowLevelErrorDef {
    * Protocol-specific status code, such as an HTTP status code.
    */
   statusCode?: string | number
+
+  /**
+   * A log level to associate with this error type since not all errors
+   * may be considered an 'error' log level type when combined with
+   * a logger.
+   */
+  logLevel?: string | number
 }
 
 /**
@@ -77,6 +92,11 @@ export interface IBaseError {
    * Get the class name of the error
    */
   getErrorName(): string
+  /**
+   * Gets the log level assigned to the error. If a low level code
+   * has a log level defined, it will be used over the high level one.
+   */
+  getLogLevel(): string | number
   /**
    * Returns the high level error code
    */
@@ -155,6 +175,13 @@ export interface IBaseError {
    * @param args
    */
   formatMessage(...args): this
+
+  /**
+   * Assign a log level to the error. Useful if you want to
+   * determine which log level to use when logging the error.
+   * @param {string|number} logLevel
+   */
+  withLogLevel(logLevel: string | number): this
 
   /**
    * Returns a json representation of the error. Assume the data


### PR DESCRIPTION
This adds the `logLevel` property to the error definitions along with corresponding `getLogLevel()` and `withLogLevel()` methods.

There are cases where certain errors do not warrant being logged under an `error` log level when combined with a logging system.