### PR TITLE
Add toJSON / toJSONSafe post-processing handler options

### DIFF
--- a/src/error-types/BaseError.ts
+++ b/src/error-types/BaseError.ts
@@ -230,7 +230,7 @@ export class BaseError extends ExtendableError implements IBaseError {
    * @param {string[]} [fieldsToOmit] An array of root properties to omit from the output
    */
   toJSON (fieldsToOmit: string[] = []): Partial<SerializedError> {
-    const data = {
+    let data: Partial<SerializedError> = {
       errId: this._errId,
       name: this.name,
       code: this._code,
@@ -253,6 +253,10 @@ export class BaseError extends ExtendableError implements IBaseError {
       this._config.omitEmptyMetadata
     ) {
       delete data.meta
+    }
+
+    if (this._config.onPreToJSONData) {
+      data = this._config.onPreToJSONData(data)
     }
 
     Object.keys(data).forEach(item => {
@@ -279,7 +283,7 @@ export class BaseError extends ExtendableError implements IBaseError {
    * @param {string[]} [fieldsToOmit] An array of root properties to omit from the output
    */
   toJSONSafe (fieldsToOmit: string[] = []): Partial<SerializedErrorSafe> {
-    const data = {
+    let data: Partial<SerializedErrorSafe> = {
       errId: this._errId,
       code: this._code,
       subCode: this._subCode,
@@ -299,6 +303,10 @@ export class BaseError extends ExtendableError implements IBaseError {
         delete data[item]
       }
     })
+
+    if (this._config.onPreToJSONSafeData) {
+      data = this._config.onPreToJSONSafeData(data)
+    }
 
     fieldsToOmit.forEach(item => {
       delete data[item]

--- a/src/error-types/__tests__/BaseError.test.ts
+++ b/src/error-types/__tests__/BaseError.test.ts
@@ -200,6 +200,25 @@ describe('BaseError', () => {
     expect(data.meta).not.toBeDefined()
   })
 
+  it('should call transformToJSONFn / transformToJSONSafeFn if defined', () => {
+    const err = new BaseError('test message', {
+      onPreToJSONData: data => {
+        data.blah = 'test'
+        return data
+      },
+      onPreToJSONSafeData: data => {
+        data.blah2 = 'test2'
+        return data
+      }
+    }).withErrorId('test-id')
+
+    const notSafe = err.toJSON()
+    const safe = err.toJSONSafe()
+
+    expect(notSafe.blah).toEqual('test')
+    expect(safe.blah2).toEqual('test2')
+  })
+
   it('should update config', () => {
     const err = new BaseError('test message', {
       toJSONSafeFieldsToOmit: ['errId']

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -247,6 +247,18 @@ export interface IBaseErrorConfig {
    * If the metadata has no data defined, remove the `meta` property on `toJSON` / `toJSONSafe`
    */
   omitEmptyMetadata?: boolean
+  /**
+   * A function to run against the computed data when calling `toJSON`. This is called prior
+   * to field omission. If defined, must return the data back.
+   */
+  onPreToJSONData?: (data: Partial<SerializedError>) => Partial<SerializedError>
+  /**
+   * A function to run against the computed safe data when calling `toJSONSafe`. This is called
+   * prior to field omission. If defined, must return the data back.
+   */
+  onPreToJSONSafeData?: (
+    data: Partial<SerializedErrorSafe>
+  ) => Partial<SerializedErrorSafe>
 }
 
 /**
@@ -287,9 +299,14 @@ export interface SerializedErrorSafe {
   logLevel?: string | number
 
   /**
-   * User-defined metadata
+   * User-defined metadata. May not be present if there is no data and omitEmptyMetadata is enabled
    */
-  meta: Record<string, any>
+  meta?: Record<string, any>
+
+  /**
+   * Other optional values
+   */
+  [key: string]: any
 }
 
 /**


### PR DESCRIPTION
You can now perform post-processing on serialized data via `onPreToJSONData` / `onPreToJSONDataSafe` options. See readme for more details.