### PR TITLE
Add the ability to convert an error to another type

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "new-error",
-  "version": "1.2.10",
+  "version": "1.3.0",
   "description": "A production-grade error creation and serialization library designed for Typescript",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/src/error-types/BaseRegistryError.ts
+++ b/src/error-types/BaseRegistryError.ts
@@ -18,6 +18,14 @@ export class BaseRegistryError extends BaseError {
     lowLevelErrorDef: LowLevelErrorInternal,
     config: IBaseErrorConfig = {}
   ) {
+    if (typeof highLevelErrorDef.onConvert === 'function') {
+      config.onConvert = highLevelErrorDef.onConvert
+    }
+
+    if (typeof lowLevelErrorDef.onConvert === 'function') {
+      config.onConvert = lowLevelErrorDef.onConvert
+    }
+
     super(lowLevelErrorDef.message, config)
 
     this.withErrorCode(highLevelErrorDef.code)

--- a/src/error-types/__tests__/BaseError.test.ts
+++ b/src/error-types/__tests__/BaseError.test.ts
@@ -244,6 +244,31 @@ describe('BaseError', () => {
     expect(err.getConfig()).toBeDefined()
   })
 
+  describe('conversion', () => {
+    it('should return false if onConvert is not defined', () => {
+      const err = new BaseError('test')
+      expect(err.hasOnConvertDefined()).toEqual(false)
+    })
+
+    it('should return true if onConvert is defined', () => {
+      const err = new BaseError('test', {
+        onConvert: () => {
+          return 'test'
+        }
+      })
+
+      expect(err.hasOnConvertDefined()).toEqual(true)
+    })
+
+    it('should update the conversion fn', () => {
+      const err = new BaseError('test')
+      err.setOnConvert(() => {
+        return 'test'
+      })
+      expect(err.hasOnConvertDefined()).toEqual(true)
+    })
+  })
+
   describe('Deserialization', () => {
     it('throws if the data is not an object', () => {
       // @ts-ignore

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,9 @@ import {
   LowLevelError,
   DeserializeOpts,
   GenerateLowLevelErrorOpts,
-  GenerateHighLevelErrorOpts
+  GenerateHighLevelErrorOpts,
+  ConvertedType,
+  ConvertFn
 } from './interfaces'
 
 export * from './utils'
@@ -25,5 +27,7 @@ export {
   SerializedErrorSafe,
   DeserializeOpts,
   GenerateLowLevelErrorOpts,
-  GenerateHighLevelErrorOpts
+  GenerateHighLevelErrorOpts,
+  ConvertedType,
+  ConvertFn
 }


### PR DESCRIPTION
This is useful if you need to convert the errors created by this library into another type, such as a `GraphQLError` when going outbound to the client.

See the README for more details.