### PR TITLE
New major version: v2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "new-error",
-  "version": "1.3.1",
+  "version": "2.0.0",
   "description": "A production-grade error creation and serialization library designed for Typescript",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/src/__tests__/ErrorRegistry.test.ts
+++ b/src/__tests__/ErrorRegistry.test.ts
@@ -6,7 +6,8 @@ import { BaseError, generateHighLevelErrors, generateLowLevelErrors } from '..'
 const errors = {
   INTERNAL_SERVER_ERROR: {
     className: 'InternalServerError',
-    code: 'INT_ERR'
+    code: 'INT_ERR',
+    message: 'Internal server error'
   },
   AUTH_ERROR: {
     className: 'AuthError',
@@ -48,26 +49,57 @@ describe('ErrorRegistry', () => {
     expect(registry.instanceOf(err, 'AUTH_ERROR')).toBe(false)
   })
 
-  it('should create a bare error instance', () => {
-    const registry = new ErrorRegistry(errors, errorCodes)
-    const err = registry.newBareError('INTERNAL_SERVER_ERROR', 'bare error msg')
+  describe('newBareError', () => {
+    it('should create a bare error instance with a message', () => {
+      const registry = new ErrorRegistry(errors, errorCodes)
+      const err = registry.newBareError(
+        'INTERNAL_SERVER_ERROR',
+        'bare error msg'
+      )
 
-    expect(registry.instanceOf(err, 'INTERNAL_SERVER_ERROR'))
+      expect(registry.instanceOf(err, 'INTERNAL_SERVER_ERROR'))
 
-    expect(err.toJSON()).toEqual(
-      expect.objectContaining({
-        message: 'bare error msg'
-      })
-    )
-  })
+      expect(err.toJSON()).toEqual(
+        expect.objectContaining({
+          message: 'bare error msg'
+        })
+      )
+    })
 
-  it('should throw if a bare error class def does not exist', () => {
-    const registry = new ErrorRegistry(errors, errorCodes)
+    it('should create a bare error instance using the high level error', () => {
+      const registry = new ErrorRegistry(errors, errorCodes)
+      const err = registry.newBareError('INTERNAL_SERVER_ERROR')
 
-    // @ts-ignore
-    expect(() => registry.newBareError('invalid', 'msg')).toThrowError(
-      /not defined/
-    )
+      expect(registry.instanceOf(err, 'INTERNAL_SERVER_ERROR'))
+
+      expect(err.toJSON()).toEqual(
+        expect.objectContaining({
+          message: 'Internal server error'
+        })
+      )
+    })
+
+    it('should create a bare error instance with the code as the message', () => {
+      const registry = new ErrorRegistry(errors, errorCodes)
+      const err = registry.newBareError('AUTH_ERROR')
+
+      expect(registry.instanceOf(err, 'AUTH_ERROR'))
+
+      expect(err.toJSON()).toEqual(
+        expect.objectContaining({
+          message: errors.AUTH_ERROR.code
+        })
+      )
+    })
+
+    it('should throw if a bare error class def does not exist', () => {
+      const registry = new ErrorRegistry(errors, errorCodes)
+
+      // @ts-ignore
+      expect(() => registry.newBareError('invalid', 'msg')).toThrowError(
+        /not defined/
+      )
+    })
   })
 
   it('should create an error instance', () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,15 +11,20 @@ import {
   GenerateLowLevelErrorOpts,
   GenerateHighLevelErrorOpts,
   ConvertedType,
-  ConvertFn
+  ConvertFn,
+  HLDefs,
+  LLDefs,
+  KeyOfStr
 } from './interfaces'
 
-export * from './utils'
+import { generateHighLevelErrors, generateLowLevelErrors } from './utils'
 
 export {
   BaseError,
   BaseRegistryError,
   ErrorRegistry,
+  generateHighLevelErrors,
+  generateLowLevelErrors,
   IBaseError,
   HighLevelError,
   LowLevelError,
@@ -29,5 +34,8 @@ export {
   GenerateLowLevelErrorOpts,
   GenerateHighLevelErrorOpts,
   ConvertedType,
-  ConvertFn
+  ConvertFn,
+  HLDefs,
+  LLDefs,
+  KeyOfStr
 }

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -34,6 +34,15 @@ export interface HighLevelError {
    * - If defined in HighLevelError, the HighLevelError definition takes priority
    */
   onConvert?: ConvertFn
+
+  /**
+   * Full description of the error. Used only when BaseError#newBareError() is called without
+   * the message parameter.
+   *
+   * sprintf() flags can be applied to customize it.
+   * @see https://www.npmjs.com/package/sprintf-js
+   */
+  message?: string
 }
 
 /**
@@ -413,6 +422,30 @@ export interface GenerateLowLevelErrorOpts {
 
 export type ConvertedType = any
 
+/**
+ * onConvert function handler definition
+ */
 export type ConvertFn = <E extends BaseError = BaseError>(
   err: E
 ) => ConvertedType
+
+/**
+ * Alias for keyof w/ string only
+ */
+export type KeyOfStr<T> = Extract<keyof T, string>
+
+/**
+ * A collection of high level error definitions
+ */
+export type HLDefs<
+  T extends string,
+  HLDef extends HighLevelErrorInternal = HighLevelErrorInternal
+> = Record<T, HLDef>
+
+/**
+ * A collection of low level error definitions
+ */
+export type LLDefs<
+  T extends string,
+  LLDef extends LowLevelErrorInternal = LowLevelErrorInternal
+> = Record<T, LLDef>

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -2,7 +2,9 @@ import {
   GenerateHighLevelErrorOpts,
   GenerateLowLevelErrorOpts,
   HighLevelErrorInternal,
-  LowLevelErrorDef,
+  HLDefs,
+  KeyOfStr,
+  LLDefs,
   LowLevelErrorInternal
 } from './interfaces'
 
@@ -12,14 +14,14 @@ import {
  * - code is the name of the property name
  */
 export function generateHighLevelErrors<
-  HLError extends Record<keyof HLError, HLInternal>,
+  HLErrors extends HLDefs<KeyOfStr<HLErrors>>,
   HLInternal extends HighLevelErrorInternal
 > (
-  errorDefs: Record<keyof HLError, Partial<HLInternal>>,
+  errorDefs: Record<keyof HLErrors, Partial<HLInternal>>,
   opts: GenerateHighLevelErrorOpts = {}
-): HLError {
+): HLErrors {
   return (Object.keys(errorDefs).reduce<
-    Record<keyof HLError, Partial<HLInternal>>
+    Record<keyof HLErrors, Partial<HLInternal>>
   >((defs, errId) => {
     if (!opts.disableGenerateClassName && !defs[errId].className) {
       defs[errId].className = toPascalCase(errId)
@@ -30,7 +32,7 @@ export function generateHighLevelErrors<
     }
 
     return defs
-  }, errorDefs) as unknown) as HLError
+  }, errorDefs) as unknown) as HLErrors
 }
 
 /**
@@ -38,21 +40,21 @@ export function generateHighLevelErrors<
  * - subCode is the name of the property name
  */
 export function generateLowLevelErrors<
-  LLErrorName extends Record<keyof LLErrorName, LLInternal>,
+  LLErrors extends LLDefs<KeyOfStr<LLErrors>>,
   LLInternal extends LowLevelErrorInternal
 > (
-  errorDefs: Record<keyof LLErrorName, Partial<LLInternal>>,
+  errorDefs: Record<keyof LLErrors, Partial<LLInternal>>,
   opts: GenerateLowLevelErrorOpts = {}
-): LLErrorName {
+): LLErrors {
   return (Object.keys(errorDefs).reduce<
-    Record<keyof LLErrorName, Partial<LLInternal>>
+    Record<keyof LLErrors, Partial<LLInternal>>
   >((defs, errId) => {
     if (!opts.disableGenerateSubCode && !defs[errId].subCode) {
       defs[errId].subCode = errId
     }
 
     return defs
-  }, errorDefs) as unknown) as LLErrorName
+  }, errorDefs) as unknown) as LLErrors
 }
 
 // https://gist.github.com/jacks0n/e0bfb71a48c64fbbd71e5c6e956b17d7


### PR DESCRIPTION
For most users, this new major version should not break your existing code.

You may have to make adjustments if you happen to use generics in `ErrorRegistry`.

- Potentially breaking: Refactor `ErrorRegistry` generics by removing unused generics and moving the definitions to an interface
- Added the ability to define a `message` in a high level definition. This is used with `ErrorRegistry#newBareError` if no message is defined.
- Made the `message` parameter of `ErrorRegistry#newBareError` optional. See readme for behavior when the parameter is omitted.